### PR TITLE
Remove add another skill link closes #45

### DIFF
--- a/app/views/veterans/_form.html.erb
+++ b/app/views/veterans/_form.html.erb
@@ -113,9 +113,6 @@
         </div>
       </div>
     </fieldset>
-    <div class="actions alternate">
-      <a onclick="addSkillOnClick()" value="+ Add Another Skill"><span aria-hidden='true'>+ </span>Add Another Skill</a>
-    </div>
   </div>
 
   <div class="form-section">


### PR DESCRIPTION
Remove add another skill link as you can add skills by pressing enter (specified in label). Still need to adjust hover styling, but cannot do it locally because my database isn't seeded with any skills yet. Waiting to hear back from @ayaleloehr on that, so I will create a new issue to address the hover styling in the meantime. 

Please review @gnakm and @emilyville!

<img width="1009" alt="screenshot 2016-02-12 16 07 49" src="https://cloud.githubusercontent.com/assets/3886085/13020465/84c10cce-d1a3-11e5-8879-3150e182eb66.png">
