### PR TITLE
Update path for favicon

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en">
 <head>
-  <link rel="shortcut icon" href="assets/icons/favicon.ico" />
+  <%= favicon_link_tag 'icons/favicon.ico' %>
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title><%= content_for?(:title) ? yield(:title) : "" %> Veterans Employment Center&trade; : Vets.gov</title>


### PR DESCRIPTION
Fixes #94 

Trying to load the favicon was throwing a 404 error, which was trying to redirect to the vets.gov 404 page which then threw a 403 error.  After some research, the issue has to do with the rails asset pipeline; the favicon is a precompiled asset in production and the code wasn't looking in the right place (let me know if you want a more detailed explanation and/or directions on how to test locally).