### PR TITLE
Removed linkedin logo from Job Seekers page

### DIFF
--- a/app/views/static_pages/_linkedin.html.erb
+++ b/app/views/static_pages/_linkedin.html.erb
@@ -3,7 +3,6 @@
   <div class="small-12 medium-4 columns card job-card">
     <div class="row">
       <div class="small-12 columns">
-        <img src="<%= image_path('linkedin_white.png')%>" alt="Linkedin 52px" data-pin-nopin="true">
         <p>Free LinkedIn Subscription</p>
       </div>
     </div>


### PR DESCRIPTION
This is for Issue #65 
Instead of adding the Coursera logo, we are removing the Linkedin logo.
@ayaleloehr please review!