### PR TITLE
Remove import from LinkedIn if Resume is imported from Skill Translator

### DIFF
--- a/app/assets/javascripts/skill_translator.js.erb
+++ b/app/assets/javascripts/skill_translator.js.erb
@@ -209,5 +209,10 @@ app.controller('SkillCtrl', ['$scope', '$http', '$timeout', '$cookies', function
     }, 500);
   }
 
+  $(function(){
+    $("#importButton").click(function(){
+      $.post('/skills-translator/resume_redirect');
+    })
+  })
 }])
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,6 @@
+class SessionsController < ApplicationController
+  def set_skills_translator_session_var
+    session[:skills_translator]=true
+    render json: nil, status: :ok
+  end
+end

--- a/app/views/veterans/_form.html.erb
+++ b/app/views/veterans/_form.html.erb
@@ -1,6 +1,6 @@
 <script type="text/javascript"  src="https://maps.googleapis.com/maps/api/js?libraries=places"%></script>
 
-<% unless session[:linkedin_profile] %>
+<% unless session[:linkedin_profile] || session[:skills_translator] %>
   <div class="row">
     <div class="small-12 medium-9 columns">
       <%= link_to "<i class='icon-linkedin' aria-hidden='true'></i><span>Auto-fill from LinkedIn</span>".html_safe, user_omniauth_authorize_path(:linkedin_resume), class: "button social linkedin", id: "linkedin_autofill"%>

--- a/app/views/veterans/new.html.erb
+++ b/app/views/veterans/new.html.erb
@@ -50,7 +50,7 @@
     <div class="small-12 columns">
       <h3>Build a Profile &amp; R&eacute;sum&eacute;</h3>  
       <p>Use this form to create a <em>public</em> profile so employers committed to hiring Veterans can find you here on the Veterans Employment Center&trade;. </p>
-      <p>Manually enter your information into the form fields below, or use the <strong>Auto-fill from LinkedIn</strong> button to pre-populate some of the fields from your LinkedIn account. <em>(Not all fields will be populated).</em></p>
+      <p>Manually enter your information into the form fields below<%unless session[:linkedin_profile] || session[:skills_translator]%>, or use the <strong>Auto-fill from LinkedIn</strong> button to pre-populate some of the fields from your LinkedIn account. <em>(Not all fields will be populated)</em><% end %>.</p>
       <%= render 'form' %>
     </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,4 +58,5 @@ EmploymentPortal::Application.routes.draw do
   post 'skills-translator/add_skill' => 'skills#add_skill'
   root 'static_pages#home'
   match '/404' => 'errors#error404', via: [ :get, :post, :patch, :delete ]
+  post 'skills-translator/resume_redirect'=> 'sessions#set_skills_translator_session_var'
 end


### PR DESCRIPTION
Fixes #108 

Importing from LinkedIn redirected to a new resume with LinkedIn info, so information already imported from the skills translator is lost.  Current solution is to disable import from LinkedIn if information has already been imported from the skills translator.

Created #179 to follow-up with more ideal functionality.