### PR TITLE
Replace trashcan icons with delete link

### DIFF
--- a/app/assets/javascripts/veterans_new.js.erb
+++ b/app/assets/javascripts/veterans_new.js.erb
@@ -72,7 +72,7 @@ function addSkill(skill) {
   var str = '<li> \
               <input value="' + skill.id + '" type="hidden" name="veteran[skills][]"> \
               <span>' + skill.name + '</span> \
-              <span class="skill-deleter"><i class="fa fa-trash-o"></i></span> \
+              <span class="skill-deleter">- delete</span> \
             </li>'
   $('#checkbox-list').append(str);
   $('#add-skill-field').typeahead('val', '');

--- a/app/assets/javascripts/veterans_new.js.erb
+++ b/app/assets/javascripts/veterans_new.js.erb
@@ -72,7 +72,7 @@ function addSkill(skill) {
   var str = '<li> \
               <input value="' + skill.id + '" type="hidden" name="veteran[skills][]"> \
               <span>' + skill.name + '</span> \
-              <span class="skill-deleter">- delete</span> \
+              <span class="skill-deleter">remove</span> \
             </li>'
   $('#checkbox-list').append(str);
   $('#add-skill-field').typeahead('val', '');

--- a/app/assets/stylesheets/skills_translator.scss
+++ b/app/assets/stylesheets/skills_translator.scss
@@ -11,7 +11,15 @@
 }
 
 .skill-deleter {
-  cursor: pointer;
+  text-decoration:underline;
+  background:rgba(0, 0, 0, 0.05);
+  color: #323a45;
+  font-size: 12px;
+}
+
+.skill-deleter:hover {
+  cursor:pointer;
+  background:#e6e6e6;
 }
 
 .add-skill-form {

--- a/app/views/veterans/_form.html.erb
+++ b/app/views/veterans/_form.html.erb
@@ -98,7 +98,7 @@
               <li>
                 <%= hidden_field(:veteran, :skills, value: skill.id, multiple: true) %>
                 <span><%= skill.name %></span>
-                <span class="skill-deleter">- delete</span>
+                <span class="skill-deleter">remove</span>
               </li>
             <% end %>
           </div>

--- a/app/views/veterans/_form.html.erb
+++ b/app/views/veterans/_form.html.erb
@@ -98,7 +98,7 @@
               <li>
                 <%= hidden_field(:veteran, :skills, value: skill.id, multiple: true) %>
                 <span><%= skill.name %></span>
-                <span class="skill-deleter"><i class="fa fa-trash-o"></i></span>
+                <span class="skill-deleter">- delete</span>
               </li>
             <% end %>
           </div>


### PR DESCRIPTION
Fixes #81 

Replaced trashcan icon with "- delete" link.  Per conversation in #81, this is preferred to icons and is better for accessibility.  I also like the consistency with the "+ Add Experience" links.