### PR TITLE
add skip_jwt to google OAuth commands

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -245,7 +245,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'
-  config.omniauth :google_oauth2, ENV['GOOGLE_OAUTH_CLIENT_ID'], ENV['GOOGLE_OAUTH_CLIENT_SECRET']
+  config.omniauth :google_oauth2, ENV['GOOGLE_OAUTH_CLIENT_ID'], ENV['GOOGLE_OAUTH_CLIENT_SECRET'], skip_jwt: true
   config.omniauth :linkedin, ENV['LINKEDIN_OAUTH_CLIENT_ID'], ENV['LINKEDIN_OAUTH_CLIENT_SECRET']
   config.omniauth :linkedin_resume, ENV['LINKEDIN_OAUTH_CLIENT_ID'], ENV['LINKEDIN_OAUTH_CLIENT_SECRET'], :scope => "r_fullprofile+r_emailaddress"
   config.omniauth :saml,


### PR DESCRIPTION
Google OAuth requests inexplicably started returning with `JWT::InvalidIatError: Invalid iat` errors without this change. 