### PR TITLE
Remove duplicate ".csv" from downloaded file

### DIFF
--- a/app/controllers/veterans_controller.rb
+++ b/app/controllers/veterans_controller.rb
@@ -38,7 +38,7 @@ class VeteransController < ApplicationController
       format.csv do
         columns = Veteran.column_names
 
-        self.response_body = StreamCSV.new("veterans.csv", self.response) do |csv|
+        self.response_body = StreamCSV.new("veterans", self.response) do |csv|
           csv << columns
           @q.result.find_each do |veteran|
             csv << columns.map{|c| veteran.send(c)}
@@ -57,7 +57,7 @@ class VeteransController < ApplicationController
       format.html
       format.csv do
         columns = Veteran.column_names
-        self.response_body = StreamCSV.new('veterans.csv', self.response) do |csv|
+        self.response_body = StreamCSV.new('veterans', self.response) do |csv|
           csv << columns
           @veterans.each do |veteran|
             csv << columns.map{|c| veteran.send(c)}


### PR DESCRIPTION
File was downloading as `veterans.csv.csv` because StreamCSV automatically puts a `.csv` on the end.  This will cause the document to properly download as `veterans.csv` now.