### PR TITLE
Enforce validation on select fields on employer edit page

### DIFF
--- a/app/assets/javascripts/employers_edit.js.erb
+++ b/app/assets/javascripts/employers_edit.js.erb
@@ -3,11 +3,11 @@ function fields_have_errors() {
   var ein = $("#employer_ein").val();
   var num_text = '';
   var error_text = '';
-  if (hiring_commitment && hiring_commitment < 1) {
+  if (hiring_commitment && (hiring_commitment < 1)) {
     num_text = '1 error';
     error_text = '<li>Commit to hire must be a postive number</li>';
   }
-  if (ein && ein.length < 9) {
+  if (ein && (ein.length < 9)) {
     if (num_text.length > 0) {
       num_text = '2 errors';
     } else {
@@ -39,7 +39,7 @@ $(document).ready(function(){
     }
   });
   // prevent sending the form on pressing enter
-  $(document).on("keypress", '#employer_form', function (e) {
+  $(document).on("keypress", function (e) {
       var code = e.keyCode || e.which;
       if (code == 13) {
           e.preventDefault();

--- a/app/assets/javascripts/employers_edit.js.erb
+++ b/app/assets/javascripts/employers_edit.js.erb
@@ -5,9 +5,9 @@ function fields_have_errors() {
   var error_text = '';
   if (hiring_commitment && (hiring_commitment < 1)) {
     num_text = '1 error';
-    error_text = '<li>Commit to hire must be a postive number</li>';
+    error_text = '<li>Commit to hire must be a positive number</li>';
   }
-  if (ein && (ein.length < 9)) {
+  if (ein && (ein.length != 9)) {
     if (num_text.length > 0) {
       num_text = '2 errors';
     } else {

--- a/app/assets/javascripts/employers_edit.js.erb
+++ b/app/assets/javascripts/employers_edit.js.erb
@@ -32,7 +32,10 @@ $(document).ready(function(){
       var error_ex = $("#error_explanation");
       error_ex.children().remove();
       error_ex.append(errors);
-      $("#error_box").show();
+      var error_box = $("#error_box");
+      error_box.show();
+      var position = error_box.offset();
+      $('html, body').animate({scrollTop: position.top}, "fast");
     }
   });
   // prevent sending the form on pressing enter

--- a/app/assets/javascripts/employers_edit.js.erb
+++ b/app/assets/javascripts/employers_edit.js.erb
@@ -1,0 +1,46 @@
+function fields_have_errors() {
+  var hiring_commitment = $("#employer_commit_to_hire").val();
+  var ein = $("#employer_ein").val();
+  var num_text = '';
+  var error_text = '';
+  if (hiring_commitment && hiring_commitment < 1) {
+    num_text = '1 error';
+    error_text = '<li>Commit to hire must be a postive number</li>';
+  }
+  if (ein && ein.length < 9) {
+    if (num_text.length > 0) {
+      num_text = '2 errors';
+    } else {
+      num_text = '1 error';
+    }
+    error_text = error_text + '<li>Employer Identification Number must be nine characters with no dashes</li>';
+  } 
+  if (error_text.length > 0) {
+    error_text = '<h3>'+num_text+' prohibited this employer from being saved:</h3><ul>'+error_text+'</ul>';
+    return error_text;
+  } else {
+    return false;
+  }
+}
+
+$(document).ready(function(){
+  $('form').on('click', '#click-button', function () {
+    var errors = fields_have_errors();
+    if (!errors){
+      $("#submit-button").click();       
+    } else {
+      var error_ex = $("#error_explanation");
+      error_ex.children().remove();
+      error_ex.append(errors);
+      $("#error_box").show();
+    }
+  });
+  // prevent sending the form on pressing enter
+  $(document).on("keypress", '#employer_form', function (e) {
+      var code = e.keyCode || e.which;
+      if (code == 13) {
+          e.preventDefault();
+          return false;
+      }
+  });
+});

--- a/app/models/employer.rb
+++ b/app/models/employer.rb
@@ -10,7 +10,7 @@ class Employer < ActiveRecord::Base
   validates_length_of :website, maximum: 255, allow_blank: true, message: "cannot exceed 255 characters"
   validates_length_of :note, maximum: 255, allow_blank: true, message: "cannot exceed 255 characters"
   validates :ein, format: { with: /\A[0-9]+\z/ }, length: { maximum: 20 }, allow_blank: true
-  validates :commit_to_hire, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: MAX_COMMIT }, 
+  validates :commit_to_hire, numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: MAX_COMMIT },
     allow_blank: true
   validates :commit_hired, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: MAX_COMMIT }, 
     allow_blank: true

--- a/app/views/employers/_form.html.erb
+++ b/app/views/employers/_form.html.erb
@@ -1,20 +1,18 @@
 <%= form_for(@employer) do |f| %>
-  <% if @employer.errors.any? %>
-    <div class="row">
-      <div class="small-12 columns">
-        <div data-alert class="alert-box warning">
-          <div id="error_explanation">
-            <h3><%= pluralize(@employer.errors.count, "error") %> prohibited this employer from being saved:</h3>
-            <ul>
-              <% @employer.errors.full_messages.each do |msg| %>
-                <li><%= msg %></li>
-              <% end %>
-            </ul>
-          </div>
+  <div class="row" id="error_box" <% if !@employer.errors.any? %> style="display:none;" <%end%>>
+    <div class="small-12 columns">
+      <div data-alert class="alert-box warning">
+        <div id="error_explanation">
+          <h3><%= pluralize(@employer.errors.count, "error") %> prohibited this employer from being saved:</h3>
+          <ul>
+            <% @employer.errors.full_messages.each do |msg| %>
+              <li><%= msg %></li>
+            <% end %>
+          </ul>
         </div>
       </div>
     </div>
-  <% end %>
+  </div>
 
   <div class="panel">
     <h3>Company Details (required)</h3>
@@ -184,7 +182,8 @@
   	<div class="row">
 		  <div class="small-12 columns">
         <div class="actions">
-    		  <%= f.submit class: "button primary" %>
+                  <span id="click-button" class: "button primary">Update Employer</span>
+                  <%= f.submit style: "display:none;", class: "button primary", id: "submit-button" %>
 		    </div>
       </div>
   	</div>

--- a/app/views/employers/_form.html.erb
+++ b/app/views/employers/_form.html.erb
@@ -182,8 +182,8 @@
   	<div class="row">
 		  <div class="small-12 columns">
         <div class="actions">
-                  <span id="click-button" class: "button primary">Update Employer</span>
-                  <%= f.submit style: "display:none;", class: "button primary", id: "submit-button" %>
+                  <span id="click-button" class="button primary">Update Employer</span>
+                  <%= f.submit style: "display:none;", id: "submit-button" %>
 		    </div>
       </div>
   	</div>

--- a/app/views/employers/_form.html.erb
+++ b/app/views/employers/_form.html.erb
@@ -165,26 +165,30 @@
 
     <% if current_user.va_admin? %>
       <div class="row form-group">
-		    <div class="small-12 columns">
-			    <%= f.label :admin_notes, "Admin Notes" %>
-				  <%= f.text_field :admin_notes, class: "form-control" %>
-		    </div>
-	    </div>
+        <div class="small-12 columns">
+          <%= f.label :admin_notes, "Admin Notes" %>
+          <%= f.text_field :admin_notes, class: "form-control" %>
+        </div>
+      </div>
 
       <div class="row form-group">
-  		  <div class="small-12 columns">
-  			  <%= f.label :approved, "Approved" %>
-  			  <%= f.check_box :approved, class: "form-control" %>
-  		  </div>
-  	  </div>
+        <div class="small-12 columns">
+	  <%= f.label :approved, "Approved" %>
+	  <%= f.check_box :approved, class: "form-control" %>
+        </div>
+      </div>
     <% end %>
 
-  	<div class="row">
-		  <div class="small-12 columns">
+    <div class="row">
+      <div class="small-12 columns">
         <div class="actions">
-                  <span id="click-button" class="button primary">Update Employer</span>
-                  <%= f.submit style: "display:none;", id: "submit-button" %>
-		    </div>
+	  <% if current_user.va_admin? %>
+	    <%= f.submit class: "button primary", id: "submit-button" %>
+	  <% else %>
+	    <span id="click-button" class="button primary">Update Employer</span>
+	    <%= f.submit style: "display:none;", id: "submit-button" %>
+	  <% end %>
+        </div>
       </div>
   	</div>
 

--- a/app/views/employers/_form.html.erb
+++ b/app/views/employers/_form.html.erb
@@ -182,12 +182,8 @@
     <div class="row">
       <div class="small-12 columns">
         <div class="actions">
-	  <% if current_user.va_admin? %>
-	    <%= f.submit class: "button primary", id: "submit-button" %>
-	  <% else %>
-	    <span id="click-button" class="button primary">Update Employer</span>
-	    <%= f.submit style: "display:none;", id: "submit-button" %>
-	  <% end %>
+	  <span id="click-button" class="button primary">Update Employer</span>
+	  <%= f.submit style: "display:none;", id: "submit-button" %>
         </div>
       </div>
   	</div>

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -39,7 +39,7 @@ FactoryGirl.define do
       association :user, factory: :user_with_random_email
       commit_date {(rand(3)+1).months.from_now}
       commit_hired {rand(5)}
-      commit_to_hire {commit_hired + rand(3)}
+      commit_to_hire {commit_hired + rand(3) + 1}
     end
   end
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -28,7 +28,7 @@ FactoryGirl.define do
 
   factory :employer do
   	company_name "Apple Computer"
-  	ein 1245
+  	ein 123456789
   	street_address "123 Main St"
     city "Towny"
     state "WA"

--- a/spec/features/employer_setup_spec.rb
+++ b/spec/features/employer_setup_spec.rb
@@ -212,7 +212,7 @@ feature 'admins can edit an employer', js: true do
     visit edit_employer_path(employer)
     fill_in "employer_admin_notes", with: 'Called and left message'
     find('#click-button').click
-    expect(page).to have_selector "#flash_notice",  text: 'was successfully updated.'
+    expect(page).to have_selector('#flash_notice', text: "#{employer.company_name} was successfully updated.")
   end
 end
 

--- a/spec/features/employer_setup_spec.rb
+++ b/spec/features/employer_setup_spec.rb
@@ -6,12 +6,12 @@ feature 'employers edit their accounts' do
     sign_in_as(@user)
   end    
   
-  scenario 'after logging in with google, they can access the edit profile page' do
+  scenario 'after logging in with google, they can access the edit profile page', :js => true do
     visit veterans_path
     click_link "Manage Your Profile and Hiring Commitment"
     expect(page).to have_selector 'h2', text: "Edit your profile"
     fill_in "employer_company_name", with: 'The Editing Company'
-    click_button "Update Employer"
+    find('#click-button').click
     expect(page).to have_selector "#flash_notice",  text: 'The Editing Company was successfully updated.'
   end
  
@@ -20,17 +20,17 @@ feature 'employers edit their accounts' do
     expect(page).to have_no_field "employer_approved"
   end
   
-  scenario 'when an employer indicates a hiring commitment category, it appears on their show page' do
+  scenario 'when an employer indicates a hiring commitment category, it appears on their show page', :js => true do
     visit edit_employer_path(@user.employer)
     check 'Homeless'
-    click_button "Update Employer"
+    find('#click-button').click
     expect(page).to have_content "Homeless"
   end
   
-  scenario 'when an employer indicates a hiring commitment number, it appears on their account and commitments pages' do
+  scenario 'when an employer indicates a hiring commitment number, it appears on their account and commitments pages', :js => true do
     visit edit_employer_path(@user.employer)
     fill_in "employer_commit_to_hire", with: '500'
-    click_button "Update Employer"
+    find('#click-button').click
     visit employer_home_path
     expect(page).to have_content "publicly committed to hire 500 Veterans."
     expect(page).to have_no_content "publicly committed to hire 500 Veterans by"
@@ -41,11 +41,11 @@ feature 'employers edit their accounts' do
     expect(page).to have_no_content "You haven't yet made a public commitment to hire Veterans"
   end
   
-  scenario 'when an employer indicates a hiring commitment number AND date, both appear on their account and commitments pages' do
+  scenario 'when an employer indicates a hiring commitment number AND date, both appear on their account and commitments pages', :js => true do
     visit edit_employer_path(@user.employer)
     fill_in "employer_commit_to_hire", with: '500'
     fill_in "employer_commit_date", with: '05/15/2016'
-    click_button "Update Employer"
+    find('#click-button').click
     visit employer_home_path
     expect(page).to have_content "publicly committed to hire 500 Veterans by May 15, 2016"
     expect(page).to have_no_content "You haven't yet made a public commitment to hire Veterans"
@@ -54,28 +54,28 @@ feature 'employers edit their accounts' do
     expect(page).to have_no_content "You haven't yet made a public commitment to hire Veterans"
   end
   
-  scenario 'when an employer removes their hiring commitment number, it no longer appears on their account and commitments pages' do
+  scenario 'when an employer removes their hiring commitment number, it no longer appears on their account and commitments pages', :js => true do
     visit edit_employer_path(@user.employer)
     fill_in "employer_commit_to_hire", with: '500'
-    click_button "Update Employer"
+    find('#click-button').click
     visit employer_home_path
     expect(page).to have_content "publicly committed to hire 500 Veterans."
     visit commitments_path
     expect(page).to have_content "publicly committed to hire 500 Veterans."
     visit edit_employer_path(@user.employer)
     fill_in "employer_commit_to_hire", with: ''
-    click_button "Update Employer"
+    find('#click-button').click
     visit employer_home_path
     expect(page).to have_content "You haven't yet made a public commitment to hire Veterans"
     visit commitments_path
     expect(page).to have_content "You haven't yet made a public commitment to hire Veterans"
   end
   
-  scenario 'an employer can specify a job posting url' do
+  scenario 'an employer can specify a job posting url', :js => true do
     visit edit_employer_path(@user.employer)
     fill_in "Employer Name", with: 'Example Inc.'
     fill_in 'URL of page with job postings', with: "http://example.com/jobs"
-    click_button "Update Employer"
+    find('#click-button').click
     expect(page).to have_content "Example Inc. was successfully updated"
   end
 

--- a/spec/features/employer_setup_spec.rb
+++ b/spec/features/employer_setup_spec.rb
@@ -198,7 +198,7 @@ feature "logged in admin can search for employers on employer index page" do
 end 
 
 
-feature 'admins can edit an employer' do
+feature 'admins can edit an employer', js: true do
   scenario 'they can visit the edit employer page' do
     employer = create :employer
     sign_in_as_admin
@@ -210,8 +210,8 @@ feature 'admins can edit an employer' do
     employer = create :employer
     sign_in_as_admin
     visit edit_employer_path(employer)
-    fill_in "employer_admin_notes", with: 'Called and left messag'
-    click_button "Update Employer"
+    fill_in "employer_admin_notes", with: 'Called and left message'
+    find('#click-button').click
     expect(page).to have_selector "#flash_notice",  text: 'was successfully updated.'
   end
 end

--- a/spec/features/resume_spec.rb
+++ b/spec/features/resume_spec.rb
@@ -319,7 +319,7 @@ feature "profile creation shouldn't redirect to employer login", js: true do
     visit veterans_path
     click_link "Manage Your Profile and Hiring Commitment"
     fill_in "employer_company_name", with: 'The Editing Company'
-    click_button "Update Employer"
+    find('#click-button').click
     click_link 'Sign Out'
 
     visit new_veteran_path

--- a/spec/models/employer_spec.rb
+++ b/spec/models/employer_spec.rb
@@ -29,13 +29,13 @@ describe Employer do
     employer = create(:employer)
     expect(employer).to be_valid
 
-    invalid = ["alpha", -12, 11111111]
+    invalid = [0, "alpha", -12, 11111111]
     invalid.each do |ex|
       employer.commit_to_hire = ex
       expect(employer).to be_invalid
     end
 
-    valid = [0, "123", 2342352]
+    valid = [1, "123", 2342352]
     valid.each do |ex|
       employer.commit_to_hire = ex
       expect(employer).to be_valid


### PR DESCRIPTION
Addresses two requested validations:
1) Hiring commitment should be greater than or equal to one
2) EIN should be 9 characters long (originally requested in #131 )

Final validation on EIN (no duplicates) will be addressed in separate task.

Let me know if you have any questions!

Discussed design somewhat with Gina but we could still run the final product by her...ping me if you want me to add screenshots.