### PR TITLE
update resume page with careers and employment changes

### DIFF
--- a/app/views/veterans/_form.html.erb
+++ b/app/views/veterans/_form.html.erb
@@ -1,12 +1,7 @@
 <script type="text/javascript"  src="https://maps.googleapis.com/maps/api/js?libraries=places"%></script>
 
 <% unless session[:linkedin_profile] %>
-  <div class="row">
-    <div class="small-12 medium-9 columns">
       <%= link_to "<i class='icon-linkedin' aria-hidden='true'></i><span>Auto-fill from LinkedIn</span>".html_safe, user_omniauth_authorize_path(:linkedin_resume), class: "button social linkedin", id: "linkedin_autofill"%>
-    </div>
-  </div>
-  <p>LinkedIn is also providing a <b>free</b> 1-year Job Seeker Premium subscription ($360 value) to all U.S. Veterans and Servicemembers. Learn more <a href="https://veterans.linkedin.com/" id="linkedin_site" target="_blank">here</a>.</p>
 <% end %>
 
 <%= form_for @veteran, html: { class: 'f resume', id: 'veteran_form', role: 'form' } do |f| %>

--- a/app/views/veterans/new.html.erb
+++ b/app/views/veterans/new.html.erb
@@ -18,11 +18,15 @@
   <% if user_signed_in? %>
     <div class="section one">
     <div class="row">
-    <div class="small-12 columns">
+    <div class="small-12 medium-9 columns">
+    <div class="primary">
       <% if current_user.is_veteran? %>
         <% if current_user.veteran.nil? %>
-        <h3>Build a Profile &amp; R&eacute;sum&eacute;</h3>
-        <p>Use this form to create a <em>public</em> profile so employers committed to hiring Veterans can find you here on the Veterans Employment Center&trade;. Completing these fields will also provide you with the building blocks to take your experience and customize it into a tailored résumé. On the next page, you will be given the opportunity to upload your profile and download the content to build your résumé.</p>
+
+          <p>The Veterans Employment Center™ (VEC) can help you build your profile so potential employers can find you on vets.gov. This profile can then be downloaded into a civilian or federal résumé.Your public job-seeker profile will be stored on vets.gov, and you can update your information as often as needed.</p>
+
+          <p>Manually enter your information into the form fields below, or use the Auto-fill from LinkedIn button to pre-populate some of the fields from your LinkedIn account.</p>
+
         <%= render 'form' %>
         <% else %>
           <p>You already have a r&eacute;sum&eacute;. Edit it <%= link_to "here", edit_veteran_path(current_user.veteran) %>.</p>
@@ -33,6 +37,7 @@
           <p>If you would also like to post a r&eacute;sum&eacute;, please sign out and return to this page.</p>
         </div>
       <% end %>
+    </div>  
     </div>
     </div>
     </div>
@@ -47,11 +52,21 @@
 
     <div class="section one">
     <div class="row">
+    <div class="small-12 medium-9 columns">
+    <div class="primary">
+
+      <p>The Veterans Employment Center™ (VEC) can help you build your profile so potential employers can find you on vets.gov. This profile can then be downloaded into a civilian or federal résumé. Your public job-seeker profile will be stored on vets.gov, and you can update your information as often as needed.</p>
+
+      <p>Manually enter your information into the form fields below, or use the Auto-fill from LinkedIn button to pre-populate some of the fields from your LinkedIn account.</p>
+
+    </div>
+    </div>
+    </div>
+    <div class="row">
     <div class="small-12 columns">
-      <h3>Build a Profile &amp; R&eacute;sum&eacute;</h3>  
-      <p>Use this form to create a <em>public</em> profile so employers committed to hiring Veterans can find you here on the Veterans Employment Center&trade;. </p>
-      <p>Manually enter your information into the form fields below, or use the <strong>Auto-fill from LinkedIn</strong> button to pre-populate some of the fields from your LinkedIn account. <em>(Not all fields will be populated).</em></p>
+
       <%= render 'form' %>
+
     </div>
     </div>
     </div>

--- a/app/views/veterans/new.html.erb
+++ b/app/views/veterans/new.html.erb
@@ -23,7 +23,7 @@
       <% if current_user.is_veteran? %>
         <% if current_user.veteran.nil? %>
 
-          <p>The Veterans Employment Center™ (VEC) can help you build your profile so potential employers can find you on vets.gov. This profile can then be downloaded into a civilian or federal résumé.Your public job-seeker profile will be stored on vets.gov, and you can update your information as often as needed.</p>
+          <p>The Veterans Employment Center™ (VEC) can help you build your profile so potential employers can find you on vets.gov. This profile can then be downloaded into a civilian or federal résumé. Your public job-seeker profile will be stored on vets.gov, and you can update your information as often as needed.</p>
 
           <p>Manually enter your information into the form fields below, or use the Auto-fill from LinkedIn button to pre-populate some of the fields from your LinkedIn account.</p>
 

--- a/spec/features/veterans_access_spec.rb
+++ b/spec/features/veterans_access_spec.rb
@@ -9,7 +9,7 @@ feature 'visitors begins to build a new resume' do
 
   scenario "a guest user can start a new resume" do
     visit new_veteran_path
-    expect(page).to have_selector 'h3', text: 'Build a Profile & Résumé'
+    expect(page).to have_content 'build your profile'
     expect(page).to have_no_selector 'h2', text: 'Sign in'
   end
 end

--- a/spec/features/veterans_spec.rb
+++ b/spec/features/veterans_spec.rb
@@ -8,7 +8,7 @@ feature 'visitors begins to build a new resume' do
 
   scenario "a guest user can start a new resume" do
     visit new_veteran_path
-    expect(page).to have_selector 'h3', text: 'Build a Profile & Résumé'
+    expect(page).to have_content 'build your profile'
     expect(page).not_to have_selector 'h2', text: 'Sign in'
   end
 end


### PR DESCRIPTION
update for tomorrow!

I don't know why the same or similar text blocks are on this page twice for logged in/not logged in? But I am not addressing that here! 

should look like this:

![screen shot 2016-03-30 at 8 24 25 pm](https://cloud.githubusercontent.com/assets/1307774/14164695/a0bab0f0-f6b6-11e5-94cb-b0855806e418.png)