### PR TITLE
Update nav bar

### DIFF
--- a/app/views/employers/commitments.html.erb
+++ b/app/views/employers/commitments.html.erb
@@ -13,7 +13,7 @@
       </div>
     </div>
   </div>
-
+  <%= render 'layouts/navigation' %>
   <div class="section one">
     <% unless user_signed_in? && current_user.is_employer? %>
       <div class="row">

--- a/app/views/employers/edit.html.erb
+++ b/app/views/employers/edit.html.erb
@@ -12,6 +12,7 @@
       </div>
     </div>
   </div>
+  <%= render 'layouts/navigation' %>
   <div class="section one">
     <div class="row">
       <div class="small-12 columns">

--- a/app/views/employers/index.html.erb
+++ b/app/views/employers/index.html.erb
@@ -12,7 +12,7 @@
       </div>
     </div>
   </div>
-
+  <%= render 'layouts/navigation' %>
   <div class="section one">
     <div class="row">
       <div class="small-12 columns">

--- a/app/views/employers/show.html.erb
+++ b/app/views/employers/show.html.erb
@@ -12,6 +12,7 @@
       </div>
     </div>
   </div>
+  <%= render 'layouts/navigation' %>
   <div class="section one">
 		<div class="row">
 			<div class="small-12 medium-3 columns">

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -1,4 +1,3 @@
-<%= render 'layouts/messages' %>
 <% if user_signed_in? %>
   <nav class="top-bar" data-topbar role="navigation" id="vec-user-nav">
     <ul class="title-area">
@@ -17,8 +16,6 @@
         <% end %>
         <% if current_user.is_employer? %>
           <li class="last"><%= link_to "Sign Out", destroy_user_session_path, method: :delete %></li>
-          <% unless current_user.employer.approved? %>
-          <% end %>
         <% end %>
       </ul>
     </section>

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -16,12 +16,6 @@
           <li class="divider"></li>
         <% end %>
         <% if current_user.is_employer? %>
-          <li><%= link_to "Search Veterans", veterans_path %></li>
-          <li class="divider"></li>
-          <li><%= link_to "Favorited Veterans", favorites_path %></li>
-          <li class="divider"></li>
-          <li id="welcome-message"><%= link_to "Manage Your Profile and Hiring Commitment", edit_employer_path(current_user.employer) %></li>
-          <li class="divider"></li>
           <li class="last"><%= link_to "Sign Out", destroy_user_session_path, method: :delete %></li>
           <% unless current_user.employer.approved? %>
           <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
 
 
     <div class="container">
-      <%= render 'layouts/navigation' %>
+      <%= render 'layouts/messages' %>
       <%= render 'va_common/header' %>
       <main role="main">
         <%= yield %>

--- a/app/views/static_pages/employers.html.erb
+++ b/app/views/static_pages/employers.html.erb
@@ -16,7 +16,7 @@
       </div>
     </div>
   </div>
-
+  <%= render 'layouts/navigation' %>
   <div class="section one">
 
 <% unless user_signed_in? && current_user.is_employer? %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -11,7 +11,7 @@
       </div>
     </div>
   </div>
-
+  <%= render 'layouts/navigation' %>
   <div class="section one">
 
     <div class="primary">

--- a/app/views/veterans/favorites.html.erb
+++ b/app/views/veterans/favorites.html.erb
@@ -12,6 +12,7 @@
       </div>
     </div>
   </div>
+  <%= render 'layouts/navigation' %>
   <div class="section one">
     <div class="row">
       <div class="small-12 columns">

--- a/app/views/veterans/index.html.erb
+++ b/app/views/veterans/index.html.erb
@@ -26,6 +26,7 @@ $(document).ready(function(){
       </div>
     </div>
   </div>
+  <%= render 'layouts/navigation' %>
   <div class="section one">
     <div class="row">
       <div class="small-12 columns">

--- a/spec/features/employer_setup_spec.rb
+++ b/spec/features/employer_setup_spec.rb
@@ -7,8 +7,8 @@ feature 'employers edit their accounts' do
   end    
   
   scenario 'after logging in with google, they can access the edit profile page', :js => true do
-    visit veterans_path
-    click_link "Manage Your Profile and Hiring Commitment"
+    visit employers_path
+    click_link "Your Employer Information"
     expect(page).to have_selector 'h2', text: "Edit your profile"
     fill_in "employer_company_name", with: 'The Editing Company'
     find('#click-button').click

--- a/spec/features/employer_setup_spec.rb
+++ b/spec/features/employer_setup_spec.rb
@@ -271,7 +271,7 @@ end
 feature 'logging out' do
   scenario 'when logged in, an employer can log out' do
     sign_in_as(employer_user)
-    visit employer_list_path
+    visit employers_path
     click_link 'Sign Out'
     expect(page).to have_content 'Signed out successfully'
   end

--- a/spec/features/resume_spec.rb
+++ b/spec/features/resume_spec.rb
@@ -317,9 +317,6 @@ feature "profile creation shouldn't redirect to employer login", js: true do
 
   scenario "sign in and out as employer before creating a resume as a vet" do
     visit veterans_path
-    click_link "Manage Your Profile and Hiring Commitment"
-    fill_in "employer_company_name", with: 'The Editing Company'
-    find('#click-button').click
     click_link 'Sign Out'
 
     visit new_veteran_path

--- a/spec/requests/employers_spec.rb
+++ b/spec/requests/employers_spec.rb
@@ -14,7 +14,7 @@ describe "Employers" do
   end
 
   describe "GET /employers" do
-    it "should redirect to login if not-logged-in user clicks Manage Profile in Employer sidebar" do
+    it "should redirect to login if not-logged-in user tries to search for veterans" do
       visit employer_home_path
       click_link 'Find Veteran Candidates'
       expect(page).to have_content 'Sign in with LinkedIn'
@@ -43,13 +43,13 @@ describe "Employers" do
       expect(page).to have_selector 'li', text: 'Your Employer Account'
     end
 
-    it "should redirect to edit profile page if logged-in employer clicks Manage Profile in Employer sidebar" do
+    it "should redirect to edit profile page if logged-in employer searches for veterans" do
       employer = employer_user
       sign_in_as employer
       visit employer_home_path
       click_link 'Find Veteran Candidates'
       expect(page).not_to have_content 'Employer Sign in'
-      expect(page).to have_content 'Manage Your Profile and Hiring Commitment'
+      expect(page).to have_content 'Sign Out'
     end
 
     it "should prompt user to log in if they aren't yet signed in" do
@@ -64,7 +64,7 @@ describe "Employers" do
       visit employer_home_path
       click_link 'Your Hiring Commitment'
       expect(page).to have_content 'Edit your profile'
-      expect(page).to have_content 'Manage Your Profile and Hiring Commitment'
+      expect(page).to have_content 'Sign Out'
     end
 
     describe "it shows favorites correctly" do

--- a/spec/requests/static_pages_spec.rb
+++ b/spec/requests/static_pages_spec.rb
@@ -25,19 +25,19 @@ describe "Static pages" do
       user = employer_user
       sign_in_as(user)
       visit root_path
-      expect(page).to have_link 'Search Veterans', href: "/veterans"
+      expect(page).to have_link 'Sign Out'
     end
 
     it "should not have the employer top nav if logged in but not an employer" do
       user = create :user, email: 'test@example.com', password: '12345678'
       sign_in_as user
       visit root_path
-      expect(page).not_to have_link 'Search Veterans', href: "/veterans"
+      expect(page).not_to have_link 'Search Veterans'
     end
 
     it "should not have the employer top nav if not logged-in" do
       visit root_path
-      expect(page).not_to have_link 'Search Veterans', href: "/veterans"
+      expect(page).not_to have_link 'Sign Out', href: "/veterans"
     end
 
     it "should have a message to email OEC if a logged-in employer who is not approved" do

--- a/spec/requests/veterans_spec.rb
+++ b/spec/requests/veterans_spec.rb
@@ -12,8 +12,7 @@ describe "Veterans" do
       employer = employer_user
       sign_in_as employer
       visit favorites_path
-      expect(page).to have_content 'Search Veterans'
-      expect(page).to have_content 'Favorited Veterans'
+      expect(page).to have_content 'Sign Out'
     end
   end
 
@@ -27,8 +26,7 @@ describe "Veterans" do
       employer = employer_user
       sign_in_as employer
       visit favorites_path
-      expect(page).to have_content 'Search Veterans'
-      expect(page).to have_content 'Favorited Veterans'
+      expect(page).to have_content 'Sign Out'
     end
 
     context "when user is a signed in employer" do


### PR DESCRIPTION
Remove duplicated employer actions from nav bar.  Move navbar to the bottom of the vets.gov banner