### PR TITLE
Addresses issue #2676 US web standard style for all buttons

### DIFF
--- a/app/views/employers/index.html.erb
+++ b/app/views/employers/index.html.erb
@@ -15,7 +15,7 @@
       <div class="small-12 columns">
         <div class="filters">
           <fieldset>
-            <%= search_form_for @search, url: employer_list_path do |f| %>
+            <%= search_form_for @search, url: employer_list_path, class: "usa-search usa-search-big" do |f| %>
               <div class="row form-group dataItem">
                 <div class="small-12 columns">
                   <label>Keywords</label>
@@ -24,7 +24,7 @@
               </div>
               <div class="row form-group dataItem">
                 <div class="small-12 medium-8 columns">
-                  <%= f.submit "Search", class: "button primary", id: "employer-search" %>
+                  <%= button_tag "Search", class: "button primary", id: "employer-search" %>
                 </div>
               </div>
             <% end %>
@@ -114,7 +114,7 @@
     table.on('init', function(){
       $('.server-pagination').hide();
     });
-    $('input[value="Search"]').click(function(e){
+    $('button#employer-search').click(function(e){
       table.search($("#keywords").val());
       table.draw();
       e.preventDefault();

--- a/app/views/veterans/_form.html.erb
+++ b/app/views/veterans/_form.html.erb
@@ -217,26 +217,26 @@
       <%#= link_to_add_fields_location "<span aria-hidden='true'>+ </span>Add Another Location".html_safe, f, :locations %>
     </div>
   </div>
-  
-  <div class="form-section">		
-      <h3 class="no-margin">Other</h3>		
-     <fieldset class="no-margin">		
-       <legend>Enter optional additional information to add to your federal résumé.</legend>		
-       <div class="row form-group dataItem">			
-         <div class="small-12 columns">		
-           <%= f.collection_check_boxes(:status_categories, Veteran::STATUS_CATEGORIES, :to_s, :to_s) do |b| %>		
-             <%= b.check_box %> <%= b.label %> <br/>		
-           <% end %>		
-         </div>		
-       </div>		
-     </fieldset>		
+
+  <div class="form-section">
+    <h3 class="no-margin">Other</h3>
+    <fieldset class="no-margin">
+      <legend>Enter optional additional information to add to your federal résumé.</legend>
+      <div class="row form-group dataItem">
+        <div class="small-12 columns">
+          <%= f.collection_check_boxes(:status_categories, Veteran::STATUS_CATEGORIES, :to_s, :to_s) do |b| %>
+            <%= b.check_box %> <%= b.label %> <br/>
+          <% end %>
+        </div>
+      </div>
+    </fieldset>
    </div>
 
   <div class="row actions">
     <div class="small-12 columns">
-      <%= f.submit "Preview Your Résumé Content", class: 'usa-button page-end' %>
+      <%= button_tag "Preview Your Résumé Content", class: 'usa-button page-end' %>
     </div>
+    <br /><br />
   </div>
-
 
 <% end %>


### PR DESCRIPTION
Addresses https://github.com/department-of-veterans-affairs/vets-website/issues/2676
- Use button tags over input[submit] for consistent visual style

@crwallace  Please review:

This is a temporary fix for these separate apps. All submit buttons now have rounded corners corresponding to the US web standard style buttons. Essentially using a `<button>` instead of `input type=submit` is both more semantically correct and also fixes the style issues with `input type=submit` inheriting from Foundation css styles in the VA Common gem.

Ideally once all of the apps use a unified stylesheet (and most of the Foundation styles are removed?) we will be much closer to parity with US Web Standard Style