### PR TITLE
Fix CTA color on secondary buttons

### DIFF
--- a/app/assets/stylesheets/_vec.scss
+++ b/app/assets/stylesheets/_vec.scss
@@ -328,6 +328,12 @@ fieldset {
   }
 }
 
+button.success.secondary {
+  background-color: #2e8540;
+  color: white;
+  border-color: #2e8540;
+}
+
 // Veteran Search Results
 .search-results {
   ol {


### PR DESCRIPTION
Temporary fix for CTA buttons. We can probably get away from having specific CSS like this once we slowly migrate off of Foundation 
https://github.com/department-of-veterans-affairs/va_common/pull/40

![screen shot 2016-08-24 at 5 27 07 pm](https://cloud.githubusercontent.com/assets/303289/17952524/210649f4-6a20-11e6-9055-46c930ac6e40.png)
