### PR TITLE
Fix MOC validations on Skills Translator

### DIFF
--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -38,11 +38,11 @@
                   </div>
                 </div>
                 <div class="row form-group dataItem">
-                  <div class="small-12 medium-5 columns" ng-class="{'usa-input-error': (skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched) && (skillRequestForm.military_position_code.$error.required || (skillRequestForm.$submitted && !data.mo.title)) }">
-                    <label for="military_position_code" ng-class="{'usa-input-error-label': (skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched) && (skillRequestForm.military_position_code.$error.required || (skillRequestForm.$submitted && !data.mo.title)) }">Military Occupation Code (MOC) (required)</label>
+                  <div class="small-12 medium-5 columns" ng-class="{'usa-input-error': (skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched) && (skillRequestForm.military_position_code.$error.required || (skillRequestForm.$submitted && !data.mo)) }">
+                    <label for="military_position_code" ng-class="{'usa-input-error-label': (skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched) && (skillRequestForm.military_position_code.$error.required || (skillRequestForm.$submitted && !data.mo)) }">Military Occupation Code (MOC) (required)</label>
                     <div ng-show="skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched">
                       <span class="usa-input-error-message" ng-show="skillRequestForm.military_position_code.$error.required">Military Occupation Code (MOC) is required</span>
-                      <span class="usa-input-error-message" ng-show="!skillRequestForm.military_position_code.$error.required && (skillRequestForm.$submitted && !data.mo.title)">Unknown MOC</span>
+                      <span class="usa-input-error-message" ng-show="!skillRequestForm.military_position_code.$error.required && (skillRequestForm.$submitted && !data.mo)">Unknown MOC</span>
                     </div>
 
                     <input name="military_position_code" id="military_position_code" type="text" ng-model="formData.moc" required/>

--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -21,7 +21,7 @@
               <div data-alert id="errorBox" class="alert-box alert radius" ng-show="state.error" ng-cloak>
                 {{state.error}}
               </div>
-              <form novalidate name="skillRequestForm" ng-submit="submitForm()" class="single-form">
+              <form novalidate name="skillRequestForm" ng-submit="submitForm()" class="single-form" ng-cloak>
                 <fieldset class="no-margin">
                   <legend>Military Position Information:</legend>
                   <div class="row form-group dataItem">
@@ -38,11 +38,11 @@
                   </div>
                 </div>
                 <div class="row form-group dataItem">
-                  <div class="small-12 medium-5 columns" ng-class="{'usa-input-error': (skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched) && (skillRequestForm.military_position_code.$error.required || (skillRequestForm.$submitted && !data.mo)) }">
-                    <label for="military_position_code" ng-class="{'usa-input-error-label': (skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched) && (skillRequestForm.military_position_code.$error.required || (skillRequestForm.$submitted && !data.mo)) }">Military Occupation Code (MOC) (required)</label>
+                  <div class="small-12 medium-5 columns" ng-class="{'usa-input-error': (skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched) && (skillRequestForm.military_position_code.$error.required) }">
+                    <label for="military_position_code" ng-class="{'usa-input-error-label': (skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched) && (skillRequestForm.military_position_code.$error.required) }">Military Occupation Code (MOC) (required)</label>
                     <div ng-show="skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched">
                       <span class="usa-input-error-message" ng-show="skillRequestForm.military_position_code.$error.required">Military Occupation Code (MOC) is required</span>
-                      <span class="usa-input-error-message" ng-show="!skillRequestForm.military_position_code.$error.required && (skillRequestForm.$submitted && !data.mo)">Unknown MOC</span>
+                      <span class="usa-input-error-message" ng-show="!skillRequestForm.military_position_code.$error.required && (skillRequestForm.$submitted && state.error)">Unknown MOC</span>
                     </div>
 
                     <input name="military_position_code" id="military_position_code" type="text" ng-model="formData.moc" required/>


### PR DESCRIPTION
### Test case
- Branch of Service: Army
- Moc code: b12

I need to do a lot more digging into the code to understand the data shapes and Skills Translator, but this should fix the issue of the error message for "invalid MOC".  This brings the validation to parity with what was in place before we switched to using USWDS error states.

FYI the skills translator is an Angular app