### PR TITLE
Allow exiting loop when duplicate skills exist

### DIFF
--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -157,7 +157,17 @@ class SkillsController < ApplicationController
           end
           r -= s["weight"]
         end
-        break if reordered_skills.length == n
+
+        # TODO: the `skills.length == 0` condition is added to address situations where
+        # the skills contain duplicates, and `skills.delete` will remove more than one
+        # instance of a skill from the skills list. This causes a situation where
+        # `reordered_skills.length` will never reach `n`, and results in an infinite loop
+        #
+        # 1) This routine should be simplified, better tested, and added to an interface
+        # that the controller can reference, not live inside the controller.
+        # 2) This routine should perform a parameter integrity check before operation
+        # and/or the routine generating the parameters should not return duplicates.
+        break if skills.length == 0 || reordered_skills.length == n
       end
       reordered_skills.each {|s| s.delete "weight"}
       return reordered_skills


### PR DESCRIPTION
Addresses an issue causing processes to hang during skills translator queries.

Visiting https://staging.vets.gov/employment/job-seekers/skills-translator and using Army 12B causes a number of `{ id => nil, relevance => 1.0, name => nil, weight => 1.0 }` skills to be filtered by the randomization functions. The randomization expected a unique set of values, and wouldn't exit a loop properly when non-uniques were presented. The result was a request that timed out when the ELB killed it ~60s in.

<img width="1236" alt="veterans_employment_center__vets_gov" src="https://cloud.githubusercontent.com/assets/215266/18015805/7986f832-6b86-11e6-8d2d-ac3f62c7578b.png">

There may be other similar behavior causing issues in production, and we're addressing logging and monitoring to help debug them there.