### PR TITLE
Production Release -> Master Aug 26, 2016 (#353)

### DIFF
--- a/app/assets/stylesheets/_vec.scss
+++ b/app/assets/stylesheets/_vec.scss
@@ -98,7 +98,7 @@ ul li:before {
   margin-top: 1.3em;
   padding: 0.65em .65em;
 }
- 
+
 .card.information {
   background: rgba(0,0,0,.05);
   min-height: 11.2rem;
@@ -328,6 +328,12 @@ fieldset {
   }
 }
 
+button.success.secondary {
+  background-color: #2e8540;
+  color: white;
+  border-color: #2e8540;
+}
+
 // Veteran Search Results
 .search-results {
   ol {
@@ -353,7 +359,7 @@ fieldset {
 }
 
 
-// VA Crisis Line 
+// VA Crisis Line
 
 .va-crisis-line {
   &:hover, &:focus {
@@ -383,7 +389,7 @@ body {
   font-size: $base-font-size;
 }
 
-.accordion .accordion-navigation > a, 
+.accordion .accordion-navigation > a,
 .accordion dd > a {
   font-size: inherit;
   font-family: inherit;
@@ -434,7 +440,7 @@ h1 {
 
 table tr th,
 table tr td,
-table tbody tr th, 
+table tbody tr th,
 table tbody tr td,
 table thead tr th,
 table thead tr td {
@@ -454,7 +460,7 @@ dl dt, dl dd {
 }
 
 p, ul, ol, dl {
-  line-height: inherit; 
+  line-height: inherit;
 }
 
 button {
@@ -511,5 +517,9 @@ form {
   legend {
     font-size: 2rem;
     font-weight: 700;
+  }
+
+  .usa-input-error {
+    margin-top: 1em;
   }
 }

--- a/app/controllers/skills_controller.rb
+++ b/app/controllers/skills_controller.rb
@@ -157,7 +157,17 @@ class SkillsController < ApplicationController
           end
           r -= s["weight"]
         end
-        break if reordered_skills.length == n
+
+        # TODO: the `skills.length == 0` condition is added to address situations where
+        # the skills contain duplicates, and `skills.delete` will remove more than one
+        # instance of a skill from the skills list. This causes a situation where
+        # `reordered_skills.length` will never reach `n`, and results in an infinite loop
+        #
+        # 1) This routine should be simplified, better tested, and added to an interface
+        # that the controller can reference, not live inside the controller.
+        # 2) This routine should perform a parameter integrity check before operation
+        # and/or the routine generating the parameters should not return duplicates.
+        break if skills.length == 0 || reordered_skills.length == n
       end
       reordered_skills.each {|s| s.delete "weight"}
       return reordered_skills

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,0 +1,19 @@
+module FormHelper
+  def form_field(form:, type:, name:, label_text: nil, errors: {})
+    # http://api.rubyonrails.org/classes/ActionView/Helpers/TextHelper.html#method-i-concat
+    if error_message = errors.fetch(name, []).first
+      content_tag :div, class: 'usa-input-error' do
+        [
+          form.label(name, label_text, class: 'usa-input-error-label'),
+          content_tag(:span, "#{name.capitalize} #{error_message}", class: 'usa-input-error-message'),
+          form.send(type, name),
+        ].reduce(&:concat)
+      end
+    else
+      content_tag(:div) do
+        concat form.label name, label_text
+        concat form.send(type, name)
+      end
+    end
+  end
+end

--- a/app/views/employers/index.html.erb
+++ b/app/views/employers/index.html.erb
@@ -15,7 +15,7 @@
       <div class="small-12 columns">
         <div class="filters">
           <fieldset>
-            <%= search_form_for @search, url: employer_list_path do |f| %>
+            <%= search_form_for @search, url: employer_list_path, class: "usa-search usa-search-big" do |f| %>
               <div class="row form-group dataItem">
                 <div class="small-12 columns">
                   <label>Keywords</label>
@@ -24,7 +24,7 @@
               </div>
               <div class="row form-group dataItem">
                 <div class="small-12 medium-8 columns">
-                  <%= f.submit "Search", class: "button primary", id: "employer-search" %>
+                  <%= button_tag "Search", class: "button primary", id: "employer-search" %>
                 </div>
               </div>
             <% end %>
@@ -114,7 +114,7 @@
     table.on('init', function(){
       $('.server-pagination').hide();
     });
-    $('input[value="Search"]').click(function(e){
+    $('button#employer-search').click(function(e){
       table.search($("#keywords").val());
       table.draw();
       e.preventDefault();

--- a/app/views/skills/index.html.erb
+++ b/app/views/skills/index.html.erb
@@ -1,5 +1,5 @@
 <div ng-app="skill-translator" ng-controller="SkillCtrl">
-<div id="content" class="interior">
+  <div id="content" class="interior">
     <a href="#content" class="sr-only">Content starts here.</a>
     <nav class="va-nav-breadcrumbs">
       <ul class="row va-nav-breadcrumbs-list" role="menubar" aria-label="Primary">
@@ -18,155 +18,170 @@
         <div class="small-12 medium-9 columns">
           <div class="filters row skill-translator-row">
             <div class="translate-box">
-                <div data-alert id="errorBox" class="alert-box alert radius" ng-show="state.error" ng-cloak>
-                    {{state.error}}
-                </div>
-                <form name="skillRequestForm" ng-submit="submitForm()" class="single-form">
-                  <fieldset class="no-margin">
+              <div data-alert id="errorBox" class="alert-box alert radius" ng-show="state.error" ng-cloak>
+                {{state.error}}
+              </div>
+              <form novalidate name="skillRequestForm" ng-submit="submitForm()" class="single-form" ng-cloak>
+                <fieldset class="no-margin">
                   <legend>Military Position Information:</legend>
-                    <div class="row form-group dataItem">
-                      <div class="small-12 medium-5 columns">
-                      <label for="military_position_branch">Branch of Service (required)</label>
+                  <div class="row form-group dataItem">
+                    <div class="small-12 medium-5 columns"  ng-class="{'usa-input-error': (skillRequestForm.$submitted || skillRequestForm.military_position_branch.$touched) && skillRequestForm.military_position_branch.$error.required }">
+                      <label for="military_position_branch" ng-class="{'usa-input-error-label': (skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched) && skillRequestForm.military_position_code.$error.required }">Branch of Service (required)</label>
+                      <div ng-show="skillRequestForm.$submitted || skillRequestForm.military_position_branch.$touched">
+                        <span class="usa-input-error-message" ng-show="skillRequestForm.military_position_branch.$error.required">Branch of Service is required</span>
+                      </div>
                       <select name="military_position_branch" ng-model="formData.branch"
-                              ng-options="name for (name, value) in branches"
-                              required id="military_position_branch">
-                      </select>
-                      </div>
-		      <div class="small-12 medium-5 columns end">
-                        <label for="military_position_code">Military Occupation Code (MOC) (required)</label>
-                        <input name="military_position_code" id="military_position_code" type="text" ng-model="formData.moc" required/>
-                      </div>
-		     </div>
-		     <div class="row form-group dataItem">
-		      <div class="small-12 medium-5 columns">
-                        <label for="military_position_status">Code Status</label>
-                        <select name="military_position_status" id="military_position_status" ng-model="formData.status" required/>
-                          <option value="true">Active
-                          <option value="false">Inactive
-			</select>
-		      </div>
-
-		      <div class="small-12 medium-5 columns end">
-                      <label for="military_position_category">Code Category</label>
-                      <select name="military_position_category" ng-model="formData.category"
-                              ng-options="name for (name, value) in categories"
-                              required id="military_position_category">
-                      </select>
-                      </div>
-		    </div>
-                    <div class="small-12 medium-3">
-                      <input type="submit" value="Translate">
-                    </div>
-                  </fieldset>
-                </form>
-
-                <div id="militaryJobMatch" ng-show="data.mo" ng-cloak>
-                  <h4>
-                    <strong><span id="moc-code">{{data.mo.moc != 'DEFAULT' ? data.mo.moc : ""}}</span></strong>
-                    {{data.mo.moc && data.mo.moc != "DEFAULT" ? ":" : ""}}
-                     <span id="moc-title">{{data.mo.title ? data.mo.title : "(Unknown MOC)"}}</span>
-                  </h4>
-                  <label ng-if="data.mo.service && data.mo.category">{{data.mo.service}}, {{data.mo.category}}</label>
+                      ng-options="name for (name, value) in branches"
+                      required id="military_position_branch">
+                    </select>
+                    <span ng-show="formData.branch.$error.required">Select branch!</span>
+                  </div>
                 </div>
-              </div>
+                <div class="row form-group dataItem">
+                  <div class="small-12 medium-5 columns" ng-class="{'usa-input-error': (skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched) && (skillRequestForm.military_position_code.$error.required) }">
+                    <label for="military_position_code" ng-class="{'usa-input-error-label': (skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched) && (skillRequestForm.military_position_code.$error.required) }">Military Occupation Code (MOC) (required)</label>
+                    <div ng-show="skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched">
+                      <span class="usa-input-error-message" ng-show="skillRequestForm.military_position_code.$error.required">Military Occupation Code (MOC) is required</span>
+                      <span class="usa-input-error-message" ng-show="!skillRequestForm.military_position_code.$error.required && (skillRequestForm.$submitted && state.error)">Unknown MOC</span>
+                    </div>
+
+                    <input name="military_position_code" id="military_position_code" type="text" ng-model="formData.moc" required/>
+                    <div ng-show="skillRequestForm.$submitted || skillRequestForm.military_position_code.$touched">
+                    </div>
+                  </div>
+                </div>
+                <div class="row form-group dataItem">
+                  <div class="small-12 medium-5 columns">
+                    <label for="military_position_status">Code Status</label>
+                    <select name="military_position_status" id="military_position_status" ng-model="formData.status" required/>
+                      <option value="true">Active</option>
+                      <option value="false">Inactive</option>
+                    </select>
+                  </div>
+                </div>
+                <div class="row form-group dataItem">
+                  <div class="small-12 medium-5 columns">
+                    <label for="military_position_category">Code Category</label>
+                    <select name="military_position_category" ng-model="formData.category"
+                    ng-options="name for (name, value) in categories"
+                    required id="military_position_category">
+                    </select>
+                  </div>
+                </div>
+
+                <div class="small-12 medium-3">
+                  <input type="submit" value="Translate">
+                </div>
+              </fieldset>
+            </form>
+
+            <div id="militaryJobMatch" ng-show="data.mo" ng-cloak>
+              <h4 ng-if="data.mo.title">
+                <strong><span id="moc-code">{{data.mo.moc != 'DEFAULT' ? data.mo.moc : ""}}</span></strong>
+                {{data.mo.moc && data.mo.moc != "DEFAULT" ? ":" : ""}}
+                <span id="moc-title">{{data.mo.title}}</span>
+              </h4>
+              <label ng-if="data.mo.service && data.mo.category">{{data.mo.service}}, {{data.mo.category}}</label>
             </div>
           </div>
+        </div>
+      </div>
 
+      <div class="small-12 medium-9 columns">
+        <div class="row translation-results skill-translator-row" ng-show="data.mo" ng-cloak>
+
+          <div id="pill-box" ng-cloak>
+            <span ng-repeat="skill in data.shownSkills" class="skill-label"
+            id="skill_pill_{{skill.id}}"
+            ng-class="{selected: skill.selected}"
+            ng-click="toggleSkill($event)">
+            <i class="fa fa-fw"></i>
+            {{skill.name}}
+          </span>
+        </div>
+        <div class="row">
           <div class="small-12 medium-9 columns">
-            <div class="row translation-results skill-translator-row" ng-show="data.mo" ng-cloak>
-
-              <div id="pill-box" ng-cloak>
-                <span ng-repeat="skill in data.shownSkills" class="skill-label"
-                     id="skill_pill_{{skill.id}}"
-                     ng-class="{selected: skill.selected}"
-                     ng-click="toggleSkill($event)">
-                  <i class="fa fa-fw"></i>
-                  {{skill.name}}
-                </span>
-	      </div>
-              <div class="row">
-                <div class="small-12 medium-9 columns">
-                  <em>Click checkboxes to import skills into the Résumé Builder</em> 
-                </div>
-		<div>
-                  <span class="skill-label more-label" ng-click="showMoreSkills()" ng-show="data.allSkills.length > 0">
-                  <span class="btn-label"><i class="fa fa-fw fa-refresh"></i></span>
-                    See more skills
-                  </span>
-                </div>
-              </div>
-              <br>
-              <div class="row">
-                <div class="medium-6 columns">
-                  <b>Missing skills?</b> Search and add to your list
-		</div>
-              </div>
-              
-              <div class="row">
-                <div class="small-12 medium-6 columns">
-                  <form ng-submit="addSkill()" class="add-skill-form">
-                    <div class="row collapse">
-                      <div class="small-9 columns">
-                        <label for="selectSkills" class="hide">Manually search for skills</label>
-                        <input type="text" class="sfTypeahead" options="exampleOptions" datasets="typeaheadData" ng-model="state.newSkill" placeholder="Search" id="selectSkills">
-                      </div>
-                      <div class="small-3 columns">
-                        <button class="usa-button">Add</button>
-                      </div>
-                    </div>
-                  </form>
-                </div>
-
-                <div class="row translation-results skill-translator-row right" ng-show="data.mo" ng-cloak>
-                  <form id="new_resume" name="new_resume" method="post" action="<%= new_veteran_path %>" style="display:none">
-                    <input name="authenticity_token" value="<%= form_authenticity_token %>" type="hidden">
-                    <input name="moc" type="hidden" value="{{formData.moc}}">
-                    <input name="branch" type="hidden" value="{{formData.branch}}">
-                    <input name="status" type="hidden" value="{{formData.status}}">
-                    <input name="category" type="hidden" value="{{formData.category}}">
-                    <input name="skills[]" type="hidden" ng-repeat="skill in data.selectedSkills" value="{{skill.id}}">
-                  </form>
-                  <button class="success secondary" id="importButton" ng-click="newResume()">
-                    <span class="btn-label"><i class="fa fa-file-text-o"></i></span>
-                    Import into Résumé Builder
-                  </button>
-                </div>
-              </div>
-            </div>
+            <em>Click checkboxes to import skills into the Résumé Builder</em>
           </div>
-          
-          <hr>
-          <div class="small-12 medium-9 columns">
-            <h5>Tips for using the Military Skills Translator:</h5>
+          <div>
+            <span class="skill-label more-label" ng-click="showMoreSkills()" ng-show="data.allSkills.length > 0">
+              <span class="btn-label"><i class="fa fa-fw fa-refresh"></i></span>
+              See more skills
+            </span>
+          </div>
+        </div>
+        <br>
+        <div class="row">
+          <div class="medium-6 columns">
+            <b>Missing skills?</b> Search and add to your list
+          </div>
+        </div>
 
-            <ul>
-              <li>The initial set of skills will be generated by your Military Occupation Code (MOC). </li>
-              <li>You may add any missing skills by manually searching for skills or qualities not listed by the translator.</li>
-              <li>The skills you select will be imported into the Résumé Builder. Carefully select skills that best fit either a specific job description or the employment sector that interests you.</li>
-              <li>Once you have selected your skills, click the green Import into Résumé Builder button and continue to work on your résumé.</li>
-              <li>Know which skills you want to use on your résumé? Skip directly to the <a href="/employment/job-seekers/create-resume">Résumé Builder</a> to create a résumé.</li>
-            </ul>
+        <div class="row">
+          <div class="small-12 medium-6 columns">
+            <form ng-submit="addSkill()" class="add-skill-form">
+              <div class="row collapse">
+                <div class="small-9 columns">
+                  <label for="selectSkills" class="hide">Manually search for skills</label>
+                  <input type="text" class="sfTypeahead" options="exampleOptions" datasets="typeaheadData" ng-model="state.newSkill" placeholder="Search" id="selectSkills">
+                </div>
+                <div class="small-3 columns">
+                  <button class="usa-button">Add</button>
+                </div>
+              </div>
+            </form>
+          </div>
+
+          <div class="row translation-results skill-translator-row right" ng-show="data.mo" ng-cloak>
+            <form id="new_resume" name="new_resume" method="post" action="<%= new_veteran_path %>" style="display:none">
+              <input name="authenticity_token" value="<%= form_authenticity_token %>" type="hidden">
+              <input name="moc" type="hidden" value="{{formData.moc}}">
+              <input name="branch" type="hidden" value="{{formData.branch}}">
+              <input name="status" type="hidden" value="{{formData.status}}">
+              <input name="category" type="hidden" value="{{formData.category}}">
+              <input name="skills[]" type="hidden" ng-repeat="skill in data.selectedSkills" value="{{skill.id}}">
+            </form>
+            <button class="success secondary" id="importButton" ng-click="newResume()">
+              <span class="btn-label"><i class="fa fa-file-text-o"></i></span>
+              Import into Résumé Builder
+            </button>
           </div>
         </div>
       </div>
     </div>
+
+    <hr>
+    <div class="small-12 medium-9 columns">
+      <h5>Tips for using the Military Skills Translator:</h5>
+
+      <ul>
+        <li>The initial set of skills will be generated by your Military Occupation Code (MOC). </li>
+        <li>You may add any missing skills by manually searching for skills or qualities not listed by the translator.</li>
+        <li>The skills you select will be imported into the Résumé Builder. Carefully select skills that best fit either a specific job description or the employment sector that interests you.</li>
+        <li>Once you have selected your skills, click the green Import into Résumé Builder button and continue to work on your résumé.</li>
+        <li>Know which skills you want to use on your résumé? Skip directly to the <a href="/employment/job-seekers/create-resume">Résumé Builder</a> to create a résumé.</li>
+      </ul>
+    </div>
   </div>
+</div>
+</div>
+</div>
 </div>
 
 <!--   This fixes a strange Chrome/Angular bug, where if you come back
-  to this page with the browser Back button, Angular will do a
-  bad job handling the old form data in the new_resume form above.
-  It will look like the app functions fine, but then it will submit the wrong
-  skills to the resume builder (it will submit the skills from your previous query).
-  By forcing a page reload, we can clear out whatever broken caching thing
-  Angular is doing. We only want to do this on a browser Back click though,
-  otherwise we would infinitely reload the page. This hidden form is one way,
-  as browsers preserve form data when you click Back. -->
+to this page with the browser Back button, Angular will do a
+bad job handling the old form data in the new_resume form above.
+It will look like the app functions fine, but then it will submit the wrong
+skills to the resume builder (it will submit the skills from your previous query).
+By forcing a page reload, we can clear out whatever broken caching thing
+Angular is doing. We only want to do this on a browser Back click though,
+otherwise we would infinitely reload the page. This hidden form is one way,
+as browsers preserve form data when you click Back. -->
 <form name="chrome_angular_bug_fix">
-    <input type="hidden" id="page_is_dirty" name="page_is_dirty" value="0" />
+  <input type="hidden" id="page_is_dirty" name="page_is_dirty" value="0" />
 </form>
 <script>
-  var dirty_bit = document.getElementById('page_is_dirty');
-  if (dirty_bit.value == '1') window.location.reload();
-  dirty_bit.value = '1';
+var dirty_bit = document.getElementById('page_is_dirty');
+if (dirty_bit.value == '1') window.location.reload();
+dirty_bit.value = '1';
 </script>

--- a/app/views/veterans/_form.html.erb
+++ b/app/views/veterans/_form.html.erb
@@ -5,22 +5,7 @@
 <% end %>
 
 <%= form_for @veteran, html: { class: 'f resume', id: 'veteran_form', role: 'form' } do |f| %>
-  <% if @veteran.errors.any? %>
-    <div class="alert-box error_highlight">
-      <h3 class="no-margin"><%= pluralize(@veteran.errors.count, "error") %> prohibited this resume from being saved:</h3>
-      <div id="error_explanation">
-      <ul>
-        <% @veteran.errors.full_messages.each do |msg| %>
-          <li><span class="resume_error"><%= msg %></span></li>
-        <% end %>
-      </ul>
-      </div>
-    </div>
-  <% end %>
-
-
     <div class="form-section">
-
       <div class="required federal">(This section is required for <strong>Federal job applications</strong>)</div>
       <h3 class="no-margin">Add the Basics</h3>
 
@@ -29,15 +14,12 @@
 
         <div class="row form-group dataItem">
           <div class="small-12 columns">
-            <%= f.label :name, "Your full name " %>
-            <%= f.text_field :name %>
+            <%= form_field(form: f, type: :text_field, name: :name, label_text: "Your full name", errors: @veteran.errors.messages) %>
           </div>
         </div>
         <div class="row form-group dataItem">
           <div class="small-12 columns">
-            <%= f.label :email, "Your email "%>
-            <%= f.email_field :email, class: "required field" %>
-            <span class="required message" aria=describedby="veteran-email">Required</span>
+            <%= form_field(form: f, type: :email_field, name: :email, label_text: "Your email", errors: @veteran.errors.messages) %>
           </div>
         </div>
       </fieldset>
@@ -217,26 +199,26 @@
       <%#= link_to_add_fields_location "<span aria-hidden='true'>+ </span>Add Another Location".html_safe, f, :locations %>
     </div>
   </div>
-  
-  <div class="form-section">		
-      <h3 class="no-margin">Other</h3>		
-     <fieldset class="no-margin">		
-       <legend>Enter optional additional information to add to your federal résumé.</legend>		
-       <div class="row form-group dataItem">			
-         <div class="small-12 columns">		
-           <%= f.collection_check_boxes(:status_categories, Veteran::STATUS_CATEGORIES, :to_s, :to_s) do |b| %>		
-             <%= b.check_box %> <%= b.label %> <br/>		
-           <% end %>		
-         </div>		
-       </div>		
-     </fieldset>		
+
+  <div class="form-section">
+    <h3 class="no-margin">Other</h3>
+    <fieldset class="no-margin">
+      <legend>Enter optional additional information to add to your federal résumé.</legend>
+      <div class="row form-group dataItem">
+        <div class="small-12 columns">
+          <%= f.collection_check_boxes(:status_categories, Veteran::STATUS_CATEGORIES, :to_s, :to_s) do |b| %>
+            <%= b.check_box %> <%= b.label %> <br/>
+          <% end %>
+        </div>
+      </div>
+    </fieldset>
    </div>
 
   <div class="row actions">
     <div class="small-12 columns">
-      <%= f.submit "Preview Your Résumé Content", class: 'usa-button page-end' %>
+      <%= button_tag "Preview Your Résumé Content", class: 'usa-button page-end' %>
     </div>
+    <br /><br />
   </div>
-
 
 <% end %>


### PR DESCRIPTION
* Use button tags over input[submit] for consistent visual style

Fix: pass specs relating to button change

* Use USA Standard error states in resume builder

* Implement USA Standard error states on skills translator

* Fix CTA color on secondary buttons

* Fix MOC validations on Skills Translator

* Fix validations flashing on page load and button click

* Allow exiting loop when duplicate skills exist (#351)