### PR TITLE
undefined method `persisted?' for nil:NilClass

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -21,13 +21,14 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user = User.find_by_provider_and_email("linkedin", auth.info.email)
       @user.update_attributes(uid: auth.uid) if @user && @user.persisted?
     end
-    if @user.persisted?
+    if @user && @user.persisted?
       sign_in @user, event: :authentication #this will throw if @user is not activated
       set_flash_message(:notice, :success, kind: "LinkedIn") if is_navigational_format?
       redirect_to employer_home_path
     else
       session["devise.linkedin_data"] = request.env["omniauth.auth"]
       flash[:warn] = "OAuth failed with LinkedIn"
+      Rails.logger.info "OAuth Failure (LinkedIn)! auth: #{auth.inspect}"
       redirect_to employer_home_path
     end
   end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -55,6 +55,26 @@ describe Users::OmniauthCallbacksController do
         end
       end
     end
+
+    context "when the auth information does not include an email address" do
+      before do
+        omniauth_auth = OmniAuth.config.mock_auth[:linkedin]
+        omniauth_auth.uid = '12345'
+        omniauth_auth.info.email = ''
+
+        request.env["omniauth.auth"] = omniauth_auth
+
+        post :linkedin
+      end
+
+      it 'should redirect to the employer_home_path' do
+        expect(response).to redirect_to employer_home_path
+      end
+
+      it 'should set a flash warning that says the login failed' do
+        expect(flash[:warn]).to match(/failed/)
+      end
+    end
   end
 
   describe "saml" do

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -58,7 +58,7 @@ describe Users::OmniauthCallbacksController do
 
     context "when the auth information does not include an email address" do
       before do
-        omniauth_auth = OmniAuth.config.mock_auth[:linkedin]
+        omniauth_auth = OmniAuth.config.mock_auth[:linkedin].dup
         omniauth_auth.uid = '12345'
         omniauth_auth.info.email = ''
 


### PR DESCRIPTION
We're seeing this error pop up in production with new relic's exception tracking:

```
NoMethodError: undefined method `persisted?' for nil:NilClass
…app/controllers/users/omniauth_callbacks_controller.rb:   24:in `linkedin'
```

It's occurring during the [linkedin oauth](https://github.com/department-of-veterans-affairs/veterans-employment-center/blob/master/app/controllers/users/omniauth_callbacks_controller.rb#L17), and as far as I can tell is either the result of no email being provided from linkedin, or a uid that's already associated with another email address. 

A quick fix would be using `if @user && @user.persisted?` instead of `if @user.persisted` on L24, but that may just hide the issue.

Has this already been investigated?