### PR TITLE
Retry requests to Jobs API on timeout

### DIFF
--- a/lib/jobs_api.rb
+++ b/lib/jobs_api.rb
@@ -1,7 +1,24 @@
 class JobsApi
   include HTTParty
 
+  default_timeout 3  # Average response time is ~200-300ms
+
+  SEARCH_URL = "#{ENV['JOBS_API_BASE_URL']}/search.json"
+  MAX_ATTEMPTS = 2
+
   def search(options)
-    self.class.get("#{ENV['JOBS_API_BASE_URL']}/search.json", options)
+    attempts = 0
+
+    begin
+      attempts += 1
+      self.class.get(SEARCH_URL, options)
+
+    rescue Timeout::Error
+      if attempts >= MAX_ATTEMPTS
+        raise
+      else
+        retry
+      end
+    end
   end
 end

--- a/lib/jobs_api.rb
+++ b/lib/jobs_api.rb
@@ -1,7 +1,7 @@
 class JobsApi
   include HTTParty
 
-  default_timeout 3  # Average response time is ~200-300ms
+  default_timeout 10  # Average response time is ~200-300ms
 
   SEARCH_URL = "#{ENV['JOBS_API_BASE_URL']}/search.json"
   MAX_ATTEMPTS = 2

--- a/spec/lib/jobs_api_spec.rb
+++ b/spec/lib/jobs_api_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe JobsApi do
+  describe '#search' do
+    subject(:search) { described_class.new.search({}) }
+
+    context 'when a request succeeds' do
+      before do
+        expect(described_class).to receive(:get).and_return(:ok)
+      end
+
+      it { is_expected.to be(:ok) }
+    end
+
+    context 'when a request times out before MAX_ATTEMPTS reached' do
+      before do
+        expect(described_class).to receive(:get).and_raise(Timeout::Error)
+        expect(described_class).to receive(:get).and_return(:ok)
+      end
+
+      it { is_expected.to be(:ok) }
+    end
+
+    context 'when a request times out after MAX_ATTEMPTS reached' do
+      before do
+        expect(described_class).to receive(:get).twice.and_raise(Timeout::Error)
+      end
+
+      # ;( https://github.com/rspec/rspec-expectations/issues/805
+      it 'should raise Timeout::Error' do
+        expect{subject}.to raise_error(Timeout::Error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've experienced issues with hanging requests to the Heroku-based Jobs API. The ELB we've configured for VEC will return a timeout to the client after 60s. It doesn't appear that the Jobs API is undergoing any performance difficulties for these requests, though more in depth investigation may be required. This (somewhat hacky) solution will

* Add a default timeout of 3 seconds to the Jobs API request
* Retry a request to the Jobs API on timeout (once)

in the hopes of providing a more consistent and performant experience to the user.

Further investigation into the cause is on hold until the Jobs API is migrated into GC (https://github.com/department-of-veterans-affairs/devops/issues/570)