### PR TITLE
Production Release Sept 1, 2016

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -21,13 +21,14 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user = User.find_by_provider_and_email("linkedin", auth.info.email)
       @user.update_attributes(uid: auth.uid) if @user && @user.persisted?
     end
-    if @user.persisted?
+    if @user && @user.persisted?
       sign_in @user, event: :authentication #this will throw if @user is not activated
       set_flash_message(:notice, :success, kind: "LinkedIn") if is_navigational_format?
       redirect_to employer_home_path
     else
       session["devise.linkedin_data"] = request.env["omniauth.auth"]
       flash[:warn] = "OAuth failed with LinkedIn"
+      Rails.logger.info "OAuth Failure (LinkedIn)! auth: #{auth.inspect}"
       redirect_to employer_home_path
     end
   end

--- a/lib/jobs_api.rb
+++ b/lib/jobs_api.rb
@@ -1,7 +1,24 @@
 class JobsApi
   include HTTParty
 
+  default_timeout 10  # Average response time is ~200-300ms
+
+  SEARCH_URL = "#{ENV['JOBS_API_BASE_URL']}/search.json"
+  MAX_ATTEMPTS = 2
+
   def search(options)
-    self.class.get("#{ENV['JOBS_API_BASE_URL']}/search.json", options)
+    attempts = 0
+
+    begin
+      attempts += 1
+      self.class.get(SEARCH_URL, options)
+
+    rescue Timeout::Error
+      if attempts >= MAX_ATTEMPTS
+        raise
+      else
+        retry
+      end
+    end
   end
 end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -55,6 +55,26 @@ describe Users::OmniauthCallbacksController do
         end
       end
     end
+
+    context "when the auth information does not include an email address" do
+      before do
+        omniauth_auth = OmniAuth.config.mock_auth[:linkedin]
+        omniauth_auth.uid = '12345'
+        omniauth_auth.info.email = ''
+
+        request.env["omniauth.auth"] = omniauth_auth
+
+        post :linkedin
+      end
+
+      it 'should redirect to the employer_home_path' do
+        expect(response).to redirect_to employer_home_path
+      end
+
+      it 'should set a flash warning that says the login failed' do
+        expect(flash[:warn]).to match(/failed/)
+      end
+    end
   end
 
   describe "saml" do

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -58,7 +58,7 @@ describe Users::OmniauthCallbacksController do
 
     context "when the auth information does not include an email address" do
       before do
-        omniauth_auth = OmniAuth.config.mock_auth[:linkedin]
+        omniauth_auth = OmniAuth.config.mock_auth[:linkedin].dup
         omniauth_auth.uid = '12345'
         omniauth_auth.info.email = ''
 

--- a/spec/lib/jobs_api_spec.rb
+++ b/spec/lib/jobs_api_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+describe JobsApi do
+  describe '#search' do
+    subject(:search) { described_class.new.search({}) }
+
+    context 'when a request succeeds' do
+      before do
+        expect(described_class).to receive(:get).and_return(:ok)
+      end
+
+      it { is_expected.to be(:ok) }
+    end
+
+    context 'when a request times out before MAX_ATTEMPTS reached' do
+      before do
+        expect(described_class).to receive(:get).and_raise(Timeout::Error)
+        expect(described_class).to receive(:get).and_return(:ok)
+      end
+
+      it { is_expected.to be(:ok) }
+    end
+
+    context 'when a request times out after MAX_ATTEMPTS reached' do
+      before do
+        expect(described_class).to receive(:get).twice.and_raise(Timeout::Error)
+      end
+
+      # ;( https://github.com/rspec/rspec-expectations/issues/805
+      it 'should raise Timeout::Error' do
+        expect{subject}.to raise_error(Timeout::Error)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This release contains additional logging information for oauth failures that cause 500's and associated alerts, as well as a retry mechanism and timeouts for requests to the jobs API that cause ELB-5XX alerts.