### PR TITLE
Timeout and retry for US Jobs Search

### DIFF
--- a/lib/jobs_api.rb
+++ b/lib/jobs_api.rb
@@ -1,24 +1,9 @@
-class JobsApi
-  include HTTParty
-
-  default_timeout 10  # Average response time is ~200-300ms
-
+class JobsApi < RetriableSearchRequest
   SEARCH_URL = "#{ENV['JOBS_API_BASE_URL']}/search.json"
-  MAX_ATTEMPTS = 2
 
   def search(options)
-    attempts = 0
-
-    begin
-      attempts += 1
+    super do
       self.class.get(SEARCH_URL, options)
-
-    rescue Timeout::Error
-      if attempts >= MAX_ATTEMPTS
-        raise
-      else
-        retry
-      end
     end
   end
 end

--- a/lib/retriable_search_request.rb
+++ b/lib/retriable_search_request.rb
@@ -1,0 +1,23 @@
+class RetriableSearchRequest
+  include HTTParty
+
+  default_timeout 10
+
+  MAX_ATTEMPTS = 2
+
+  def search(_options)
+    attempts = 0
+
+    begin
+      attempts += 1
+      yield
+
+    rescue Timeout::Error
+      if attempts >= MAX_ATTEMPTS
+        raise
+      else
+        retry
+      end
+    end
+  end
+end

--- a/lib/us_jobs_search.rb
+++ b/lib/us_jobs_search.rb
@@ -1,9 +1,10 @@
-class UsJobsSearch
-  include HTTParty
+class UsJobsSearch < RetriableSearchRequest
   BASE_URI = 'http://api2.us.jobs/'
   API_KEY = ENV['US_JOBS_API_KEY']
 
   def search(options)
-    self.class.get(BASE_URI, query: options.merge(key: API_KEY))
+    super do
+      self.class.get(BASE_URI, query: options.merge(key: API_KEY))
+    end
   end
 end

--- a/spec/lib/retriable_search_request_spec.rb
+++ b/spec/lib/retriable_search_request_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+describe RetriableSearchRequest do
+  describe '#search' do
+    subject(:search) {
+      described_class.new.search({}) do
+        described_class.get('http://example.com')
+      end
+    }
+
+    context 'when a request succeeds' do
+      before do
+        expect(described_class).to receive(:get).and_return(:ok)
+      end
+
+      it { is_expected.to be(:ok) }
+    end
+
+    context 'when a request times out before MAX_ATTEMPTS reached' do
+      before do
+        expect(described_class).to receive(:get).and_raise(Timeout::Error)
+        expect(described_class).to receive(:get).and_return(:ok)
+      end
+
+      it { is_expected.to be(:ok) }
+    end
+
+    context 'when a request times out after MAX_ATTEMPTS reached' do
+      before do
+        expect(described_class).to receive(:get).twice.and_raise(Timeout::Error)
+      end
+
+      # ;( https://github.com/rspec/rspec-expectations/issues/805
+      it 'should raise Timeout::Error' do
+        expect{subject}.to raise_error(Timeout::Error)
+      end
+    end
+  end
+end

--- a/spec/lib/us_jobs_search_spec.rb
+++ b/spec/lib/us_jobs_search_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JobsApi do
+describe UsJobsSearch do
   describe '#search' do
     subject(:search) { described_class.new.search({}) }
 


### PR DESCRIPTION
We've been seeing a number of timeout issues with the US Jobs Search API requests. This PR involves using the same logic for the Jobs API requests, setting an explicit timeout and attempting to retry.