### PR TITLE
Add index on skills is_common

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ rm -fr /usr/local/var/postgres
 initdb /usr/local/var/postgres -E utf8
 ```
 
-
 # Git Worklow
 
   - `$ git checkout -b YOUR_BRANCH_NAME` (creates a new feature branch and switches to it)

--- a/db/migrate/20170112043901_add_skills_is_common_index.rb
+++ b/db/migrate/20170112043901_add_skills_is_common_index.rb
@@ -1,0 +1,5 @@
+class AddSkillsIsCommonIndex < ActiveRecord::Migration
+  def change
+    add_index :skills, :is_common
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160308154100) do
+ActiveRecord::Schema.define(version: 20170112043901) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -138,7 +138,7 @@ ActiveRecord::Schema.define(version: 20160308154100) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer  "belongs_to"
-    t.boolean  "is_common",  default: false
+    t.boolean  "is_common",  default: false, index: {name: "index_skills_on_is_common"}
     t.index name: "index_skills_on_name", unique: true, expression: "\"left\"(name, 1000)"
   end
 


### PR DESCRIPTION
Fixes issue observed in production: https://github.com/department-of-veterans-affairs/devops/issues/873

We have not seen this VEC issue re-occur, and there is little harm in adding a column index. The skills table is is used by resume-builder and so will live on for a while at least.

Verified that db:migrate is happy even if the index by the same name already exists, as is the case in production.

