### PR TITLE
Pv add sentry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,7 @@ gem 'activerecord-session_store', git: 'https://github.com/rails/activerecord-se
 gem 'schema_plus_pg_indexes'
 gem 'schema_plus_core'
 gem 'puma', '3.2.0'
+gem 'sentry-raven'
 
 # Generates fake data. Used to create data for staging environment's fictitious veterans, awards, affiliations, employers, etc.
 gem 'ffaker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,6 +350,8 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     selectivizr-rails (1.1.2)
+    sentry-raven (2.3.0)
+      faraday (>= 0.7.6, < 1.0)
     shellany (0.0.1)
     simplecov (0.12.0)
       docile (~> 1.1.0)
@@ -464,6 +466,7 @@ DEPENDENCIES
   schema_plus_core
   schema_plus_pg_indexes
   sdoc
+  sentry-raven
   simplecov
   therubyracer
   uglifier (>= 1.3.0)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,12 @@ pipeline {
       }
     }
 
+    stage('Update bundle-audit database') {
+      steps {
+        sh 'bash --login -c "bundle exec bundle-audit update"'
+      }
+    }
+
     stage('Run tests') {
       steps {
         sh 'bash --login -c "bundle exec rake"'

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@
 ## Troubleshooting
 
 ### Problem 1:
-
 ```
 > bundle install
 [...]

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ connections on Unix domain socket "/tmp/.s.PGSQL.5432"
 #### Fix:
 
 Try running these commands:
-
 ```
 rm -fr /usr/local/var/postgres
 initdb /usr/local/var/postgres -E utf8

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 ## Troubleshooting
 
 ### Problem 1:
+
 ```
 > bundle install
 [...]


### PR DESCRIPTION
Fixes https://github.com/department-of-veterans-affairs/vets.gov-team/issues/897

VEC is not doing any special exception handling, so relying on Sentry's default Rails integration which will capture all uncaught exceptions if SENTRY_DSN is set, which we are doing in devops with: https://github.com/department-of-veterans-affairs/devops/pull/1394