### PR TITLE
Comma separate 'Special commitments to'.

### DIFF
--- a/app/views/employers/_commitment_summary.html.erb
+++ b/app/views/employers/_commitment_summary.html.erb
@@ -12,5 +12,5 @@
 <% end %>
 <% if employer.commitment_categories.size > 0 %>
   <br />
-  <b>Special commitments to:</b> <% employer.commitment_categories.each do |comm| %><%= comm %> <% end %>
+  <b>Special commitments to:</b> <% employer.commitment_categories.join(", ") %>
 <% end %>

--- a/app/views/employers/_commitment_summary.html.erb
+++ b/app/views/employers/_commitment_summary.html.erb
@@ -12,5 +12,5 @@
 <% end %>
 <% if employer.commitment_categories.size > 0 %>
   <br />
-  <b>Special commitments to:</b> <% employer.commitment_categories.join(", ") %>
+  <b>Special commitments to:</b> <%= employer.commitment_categories.join(", ") %>
 <% end %>


### PR DESCRIPTION
Resolves department-of-veterans-affairs/vets.gov-team#3097.

I wasn't able to test it since the table wasn't populated with any companies when I tried to check locally. Not sure if I missed a step in setup.

In any case, since `employer.commitment_categories` appears to be an array, I believe this change should be all that's required.