### PR TITLE
Replace old VEC GTM Container with Vets-wide container ID

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,19 +20,19 @@
     <%= render partial: 'layouts/ie8_compatibility' %>
 
     <!-- Google Tag Manager -->
-      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-5KBL3T"
+      <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-WFJWBD"
       height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
       j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
       '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-5KBL3T');</script>
+      })(window,document,'script','dataLayer','GTM-WFJWBD');</script>
     <!-- End Google Tag Manager -->
   </head>
   <body>
 
     <a class="show-on-focus" href="#content">Skip to Content</a>
-    
+
     <div class="container">
       <%= render 'layouts/messages' %>
       <%= render 'va_common/header' %>


### PR DESCRIPTION
Replaces the old, VEC-specific GTM container `GTM-5KBL3T` with the new, Vets.gov-wide container `GTM-WFJWBD`

The old container was setup to report only basic pageviews, which the new container also has so reported data should remain the same across the switch.

This a debt clean-up to finish the consolidation of our analytics config.