### PR TITLE
patch CVE-2018-3760 by upgrading sprockets to 3.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.12.2)
-    concurrent-ruby (1.0.4)
+    concurrent-ruby (1.0.5)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.3)
@@ -251,7 +251,7 @@ GEM
     puma (3.2.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.6.9)
+    rack (1.6.10)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.7.1)
@@ -355,7 +355,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     slop (3.6.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.0)


### PR DESCRIPTION
Connects: https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11066

https://blog.heroku.com/rails-asset-pipeline-vulnerability#how-do-i-fix-it